### PR TITLE
Implemented support for custom collection names

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,3 +1,4 @@
+
 # Working with Collections
 
 The `CollectionWorker` and its response builders provide a powerful yet intuitive API to query, filter, and iterate over documents in a MongoDB collection — all while keeping your data model as a clean Pydantic class.
@@ -24,6 +25,30 @@ collection = as_collection(User, driver)
 ```
 
 By default, the collection name is inferred from the model class (`User` → `"user"`).
+
+You can customize the collection name in three ways:
+
+### 1. Override at runtime
+
+```python
+collection = as_collection(User, driver, collection_name="myusers")
+```
+
+### 2. Use Pydantic `ConfigDict`
+
+```python
+from pydantic import ConfigDict
+
+class User(BaseModel):
+    name: str
+    age: int
+
+    model_config = ConfigDict(collection_name="customusers")
+```
+
+### 3. Fallback to default
+
+If neither is set, the collection name is derived from the model class: `User` → `"users"`.
 
 ---
 
@@ -119,5 +144,9 @@ for user in results:
 - Works for both sync and async workflows
 - Returns `DocumentWorker`/`AsyncDocumentWorker` instances
 - Supports fluent chaining and expressive filter logic
+- Custom collection names can be set via:
+  - `collection_name` argument
+  - `model_config = ConfigDict(collection_name=...)`
+  - Class name fallback
 
 Pydongo gives you clean Mongo-style querying with the structure of Pydantic — no inheritance, no decorators, just Python.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from pydongo.drivers.mock import MockMongoDBDriver, MockAsyncMongoDBDriver
+
+
+@pytest.fixture
+def driver():
+    return MockMongoDBDriver()
+
+
+@pytest.fixture
+def async_driver():
+    return MockAsyncMongoDBDriver()

--- a/tests/test_collection_naming_config.py
+++ b/tests/test_collection_naming_config.py
@@ -1,0 +1,53 @@
+from pydantic import BaseModel, ConfigDict
+from pydongo import as_collection, as_document
+from pydongo.drivers.mock import MockMongoDBDriver
+
+
+class UserWithModelConfig(BaseModel):
+
+    age: int = 19
+    n_likes: int = 0
+
+    model_config = ConfigDict(collection_name="customusers")
+
+
+class User(BaseModel):
+
+    age: int = 19
+    n_likes: int = 0
+
+
+def test_default_collection_name_set_correctly(driver):
+
+    expected_collection_name = "users"
+
+    collection = as_collection(User, driver)
+    assert collection.collection_name == expected_collection_name
+
+    document = as_document(User(), driver)
+    assert document.collection_name == expected_collection_name
+
+
+def test_configured_collection_name_set_correctly(driver):
+
+    expected_collection_name = "customusers"
+    collection = as_collection(UserWithModelConfig, driver)
+    assert collection.collection_name == expected_collection_name
+
+    document = as_document(UserWithModelConfig(), driver)
+    assert document.collection_name == expected_collection_name
+
+
+def test_custom_collection_name_set_correctly(driver):
+
+    collection_name = "myusers"
+
+    collection = as_collection(User, driver=driver, collection_name=collection_name)
+    assert collection.collection_name == collection_name
+    collection = as_collection(UserWithModelConfig, driver=driver, collection_name=collection_name)
+    assert collection.collection_name == collection_name
+
+    document = as_document(User(), driver=driver, collection_name=collection_name)
+    assert document.collection_name == collection_name
+    document = as_document(UserWithModelConfig(), driver=driver, collection_name=collection_name)
+    assert document.collection_name == collection_name


### PR DESCRIPTION
## Summary
This PR introduces support for specifying custom MongoDB collection names directly from your Pydantic model using model_config. It also ensures collection names can still be overridden at runtime or inferred from the model name by default.

## Updates
- as_collection() and as_document() now respect model_config = ConfigDict(collection_name=...) on the model class
- Added fallback behavior:
    - Priority 1: collection_name argument
    - Priority 2: model_config.collection_name
    - Priority 3: Inferred from class name (e.g., User → "user")
-  Full test coverage for all cases
- Updated the “Working with Collections” doc to reflect the new behavior

